### PR TITLE
search in PATH for python

### DIFF
--- a/examples/hello_world.py
+++ b/examples/hello_world.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright (c) PLUMgrid, Inc.
 # Licensed under the Apache License, Version 2.0 (the "License")
 


### PR DESCRIPTION
This commit is improving fail safety a bit by instructing to search `PATH` for python in the - may unlikely - case it’s not located at `/bin`